### PR TITLE
Phar distribution

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,20 @@
+{
+    "output": "karma.phar",
+    "main": "karma",
+     "compactors": [
+        "Herrera\\Box\\Compactor\\Php"
+    ],
+    "extract": false,
+    "finder": [
+        {
+            "name": "*.*",
+            "exclude": ["Tests"],
+            "in": "vendor"
+        },
+        {
+            "name": "*.*",
+            "in": "src"
+        }
+    ],
+    "stub": true
+}


### PR DESCRIPTION
Here is how to compile 
- download box.phar from https://github.com/box-project/box2/releases
- run composer install without dev deps `composer install --no-dev`
- build the phar distribution with `php box.phar build`

The Phar distribution is <1M

``` shell
killerbookpro:karma killerwolf$ ls -alh|grep karma.phar
-rw-r--r--   1 killerwolf  staff   913K Oct 23 00:03 karma.phar
killerbookpro:karma killerwolf$ php karma.phar -V
Karma version 5.3.0
```

Enjoy

TODOs:
- Automate phar dist within build.xml and trigger it with travis
- Mimic composer `--version` command, which returns 'the tag, short-hash and build time'
- Release these phars under github/release page (and/or even bintray)
- Find a way to test the phar distribution (within travis maybe)
- ...
