### PR TITLE
Add targetPath for config output

### DIFF
--- a/src/Karma/Application.php
+++ b/src/Karma/Application.php
@@ -127,24 +127,14 @@ class Application extends \Pimple
 
         $this['target.fileSystem.adapter'] = function($c) {
 
-            if($c['target.path'] !== $c['sources.path'])
+            if(! empty($c['target.path']))
             {
                 $c['hydrator.allowNonDistFilesOverwrite'] = true;
-            }
 
-            if(! is_array($c['target.path']))
-            {
                 return new Local($c['target.path']);
             }
 
-            $adapter = new MultipleAdapter();
-
-            foreach($c['target.path'] as $path)
-            {
-                $adapter->mount($path, new Local($path));
-            }
-
-            return $adapter;
+            return $this['sources.fileSystem.adapter'];
         };
 
         $this['target.fileSystem'] = function($c) {

--- a/src/Karma/Command/ConfigureActionCommand.php
+++ b/src/Karma/Command/ConfigureActionCommand.php
@@ -112,6 +112,11 @@ abstract class ConfigureActionCommand extends Command
 
         $targetPath = $input->getOption('targetPath');
 
+        if(is_array($targetPath))
+        {
+            throw new \RuntimeException('Invalid argument targetPath : could not be mutiple (single path required as string)');
+        }
+
         if(empty($targetPath) && $profile->hasTargetPath() === true)
         {
             $targetPath = $profile->getTargetPath();

--- a/src/Karma/Command/ConfigureActionCommand.php
+++ b/src/Karma/Command/ConfigureActionCommand.php
@@ -55,6 +55,7 @@ abstract class ConfigureActionCommand extends Command
 
             ->addArgument('sourcePath', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'source path to hydrate/generate')
 
+            ->addOption('targetPath', 't', InputOption::VALUE_REQUIRED, 'target path to hydrate/generate', null)
             ->addOption('env', 'e', InputOption::VALUE_REQUIRED, 'Target environment', self::ENV_DEV)
             ->addOption('system', 's', InputOption::VALUE_REQUIRED, 'Target environment for system variables', null)
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Simulation mode')
@@ -92,10 +93,10 @@ abstract class ConfigureActionCommand extends Command
             $this->output->writeln("<fg=cyan>Backup enabled</fg=cyan>");
         }
 
+        $profile = $this->app['profile'];
         $sourcePath = $input->getArgument('sourcePath');
         if(empty($sourcePath))
         {
-            $profile = $this->app['profile'];
             if($profile->hasSourcePath() !== true)
             {
                 throw new \RuntimeException('Missing argument sourcePath');
@@ -108,7 +109,14 @@ abstract class ConfigureActionCommand extends Command
         {
             $sourcePath = array($sourcePath);
         }
-        
+
+        $targetPath = $input->getOption('targetPath');
+
+        if(empty($targetPath) && $profile->hasTargetPath() === true)
+        {
+            $targetPath = $profile->getTargetPath();
+        }
+
         $this->output->writeln(sprintf(
             "<info>%s <comment>%s</comment> with <comment>%s</comment> values</info>",
             $this->outputTitle,
@@ -118,6 +126,12 @@ abstract class ConfigureActionCommand extends Command
         $this->output->writeln('');
 
         $this->app['sources.path'] = $sourcePath;
+
+        $this->app['target.path'] = $targetPath;
+        if(empty($targetPath))
+        {
+            $this->app['target.path'] = $sourcePath;
+        }
 
         $this->processOverridenVariables(
             $this->parseOptionWithAssignments($input, 'override')

--- a/src/Karma/Command/ConfigureActionCommand.php
+++ b/src/Karma/Command/ConfigureActionCommand.php
@@ -126,12 +126,7 @@ abstract class ConfigureActionCommand extends Command
         $this->output->writeln('');
 
         $this->app['sources.path'] = $sourcePath;
-
         $this->app['target.path'] = $targetPath;
-        if(empty($targetPath))
-        {
-            $this->app['target.path'] = $sourcePath;
-        }
 
         $this->processOverridenVariables(
             $this->parseOptionWithAssignments($input, 'override')

--- a/src/Karma/Hydrator.php
+++ b/src/Karma/Hydrator.php
@@ -102,20 +102,20 @@ class Hydrator implements ConfigurableProcessor
 
     public function hydrate($environment)
     {
-        $distFiles = $this->collectDistFiles();
+        $files = $this->collectFiles();
 
-        foreach($distFiles as $file)
+        foreach($files as $file)
         {
             $this->hydrateFile($file, $environment);
         }
 
         $this->info(sprintf(
            '%d files generated',
-            count($distFiles)
+            count($files)
         ));
     }
 
-    private function collectDistFiles()
+    private function collectFiles()
     {
         $pattern = sprintf('.*\%s$', $this->suffix);
         if($this->nonDistFilesOverwriteAllowed === true)
@@ -390,9 +390,9 @@ class Hydrator implements ConfigurableProcessor
 
     public function rollback()
     {
-        $distFiles = $this->collectDistFiles();
+        $files = $this->collectFiles();
 
-        foreach($distFiles as $file)
+        foreach($files as $file)
         {
             $this->rollbackFile($file);
         }

--- a/src/Karma/Hydrator.php
+++ b/src/Karma/Hydrator.php
@@ -117,7 +117,7 @@ class Hydrator implements ConfigurableProcessor
 
     private function collectFiles()
     {
-        $pattern = sprintf('.*\%s$', $this->suffix);
+        $pattern = sprintf('.*%s$', preg_quote($this->suffix));
         if($this->nonDistFilesOverwriteAllowed === true)
         {
             $pattern = '.*';
@@ -128,7 +128,7 @@ class Hydrator implements ConfigurableProcessor
 
     private function hydrateFile($file, $environment)
     {
-        $this->currentTargetFile = preg_replace(sprintf('~(.*)(\%s)$~', $this->suffix), '$1', $file);
+        $this->currentTargetFile = preg_replace(sprintf('~(.*)(%s)$~', preg_quote($this->suffix)), '$1', $file);
 
         if($this->nonDistFilesOverwriteAllowed)
         {

--- a/src/Karma/Hydrator.php
+++ b/src/Karma/Hydrator.php
@@ -133,6 +133,11 @@ class Hydrator implements ConfigurableProcessor
         if($this->nonDistFilesOverwriteAllowed)
         {
             $this->currentTargetFile = (new \SplFileInfo($this->currentTargetFile))->getFilename();
+
+            if($this->target->has($this->currentTargetFile))
+            {
+                throw new \RuntimeException(sprintf('The fileName "%s" is defined in 2 config folders (not allowed with targetPath config enabled)', $this->currentTargetFile));
+            }
         }
 
         $content = $this->sources->read($file);

--- a/src/Karma/Hydrator.php
+++ b/src/Karma/Hydrator.php
@@ -117,7 +117,7 @@ class Hydrator implements ConfigurableProcessor
 
     private function collectDistFiles()
     {
-        $pattern = '.*\-dist$';
+        $pattern = sprintf('.*\%s$', $this->suffix);
         if($this->nonDistFilesOverwriteAllowed === true)
         {
             $pattern = '.*';

--- a/src/Karma/ProfileReader.php
+++ b/src/Karma/ProfileReader.php
@@ -65,10 +65,14 @@ class ProfileReader implements FormattersDefinition
 
         foreach(array_keys($this->attributes) as $name)
         {
-            if(isset($values[$name]))
+            if(! isset($values[$name]))
             {
-                $this->attributes[$name] = $values[$name];
+                continue;
             }
+
+            $this->ensureParameterFormatIsValid($name, $values[$name]);
+
+            $this->attributes[$name] = $values[$name];
         }
     }
 
@@ -174,5 +178,27 @@ class ProfileReader implements FormattersDefinition
         }
 
         return $value;
+    }
+
+    private function ensureParameterFormatIsValid($parameter, $value)
+    {
+        $parameterValidators = array(
+            'targetPath' => function($value) {
+                return is_string($value);
+            }
+        );
+
+        if(
+            ! array_key_exists($parameter, $parameterValidators)
+            || ! $parameterValidators[$parameter] instanceof \Closure
+        )
+        {
+            return true;
+        }
+
+        if(! $parameterValidators[$parameter]($value))
+        {
+            throw new \RuntimeException('Paramater %s format is invalid');
+        }
     }
 }

--- a/src/Karma/ProfileReader.php
+++ b/src/Karma/ProfileReader.php
@@ -13,6 +13,7 @@ class ProfileReader implements FormattersDefinition
         MASTER_FILENAME_INDEX = 'master',
         CONFIGURATION_DIRECTORY_INDEX = 'confDir',
         SOURCE_PATH_INDEX = 'sourcePath',
+        TARGET_PATH_INDEX = 'targetPath',
         DEFAULT_FORMATTER_INDEX = 'defaultFormatter',
         FORMATTERS_INDEX = 'formatters',
         FILE_EXTENSION_FORMATTERS_INDEX = 'fileExtensionFormatters',
@@ -28,6 +29,7 @@ class ProfileReader implements FormattersDefinition
             self::MASTER_FILENAME_INDEX => null,
             self::CONFIGURATION_DIRECTORY_INDEX => null,
             self::SOURCE_PATH_INDEX => null,
+            self::TARGET_PATH_INDEX => null,
             self::DEFAULT_FORMATTER_INDEX => self::DEFAULT_FORMATTER_NAME,
             self::FORMATTERS_INDEX => array(),
             self::FILE_EXTENSION_FORMATTERS_INDEX => array(),
@@ -108,6 +110,16 @@ class ProfileReader implements FormattersDefinition
     public function getSourcePath()
     {
         return $this->get(self::SOURCE_PATH_INDEX);
+    }
+
+    public function hasTargetPath()
+    {
+        return $this->has(self::TARGET_PATH_INDEX);
+    }
+
+    public function getTargetPath()
+    {
+        return $this->get(self::TARGET_PATH_INDEX);
     }
 
     public function getDefaultFormatterName()

--- a/tests/Karma/Command/HydrateTest.php
+++ b/tests/Karma/Command/HydrateTest.php
@@ -20,6 +20,8 @@ class HydrateTest extends CommandTestCase
         $this->app['sources.fileSystem.adapter'] = new InMemory(array(
             'src/file-dist' => '<%app.foo%>',
         ));
+
+        $this->app['target.fileSystem.adapter'] = new InMemory();
     }
 
     /**
@@ -30,7 +32,7 @@ class HydrateTest extends CommandTestCase
         $mock = $this->getMock(
             'Karma\Hydrator',
             array(),
-            array($this->app['sources.fileSystem'], $this->app['configuration'], $this->app['finder'])
+            array($this->app['sources.fileSystem'], $this->app['target.fileSystem'], $this->app['configuration'], $this->app['finder'])
         );
 
         $mock->expects($this->once())
@@ -128,6 +130,8 @@ YAML;
         $this->app['sources.fileSystem.adapter'] = $adapter = new InMemory(array(
             'src/file-dist' => '<%foo%>',
         ));
+        
+        $this->app['target.fileSystem.adapter'] = $adapter = new InMemory();
 
         $this->runCommand(self::COMMAND_NAME, array(
             '--override' => array('foo=[1,2,3]'),

--- a/tests/Karma/Command/RollbackCommandTest.php
+++ b/tests/Karma/Command/RollbackCommandTest.php
@@ -27,7 +27,7 @@ class RollbackCommandTest extends CommandTestCase
         $mock = $this->getMock(
             'Karma\Hydrator',
             array(),
-            array($this->app['sources.fileSystem'], $this->app['configuration'], $this->app['finder'])
+            array($this->app['sources.fileSystem'], $this->app['target.fileSystem'], $this->app['configuration'], $this->app['finder'])
         );
         $mock->expects($this->once())
             ->method($expectedMethodCall);

--- a/tests/Karma/HydratorTest.php
+++ b/tests/Karma/HydratorTest.php
@@ -157,7 +157,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
     
     public function testTrappedFilenamesToTarget()
     {
-        $existingFiles = array('a.php', 'b.php-dist', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php', 'h.php-dist-dist');
+        $existingFiles = array('a.php', 'b.php-dist', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php', 'h.php-dist-dist', 'dist-dir/z-dist');
     
         foreach($existingFiles as $file)
         {
@@ -168,7 +168,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
             ->allowNonDistFilesOverwrite()
             ->hydrate('prod');
     
-        $expectedFiles = array('b.php', 'h.php-dist', 'a.php', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php');
+        $expectedFiles = array('b.php', 'h.php-dist', 'a.php', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php', 'z');
         
         // check there is no extra generated file
         $this->assertSame(count($expectedFiles), count($this->targetFs->keys()));
@@ -179,6 +179,32 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         }
     }
     
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testDuplicatedFilenamesToTarget()
+    {
+        $existingFiles = array('dist-1/test.php-dist', 'dist-2/test.php-dist');
+
+        foreach($existingFiles as $file)
+        {
+            $this->write($file);
+        }
+
+        $this->hydrator
+            ->allowNonDistFilesOverwrite()
+            ->hydrate('prod');
+
+        $expectedFiles = array('b.php', 'h.php-dist', 'a.php', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php', 'z');
+
+        // check there is no extra generated file
+        $this->assertSame(count($expectedFiles), count($this->targetFs->keys()));
+
+        foreach($expectedFiles as $file)
+        {
+            $this->assertTrue($this->targetFs->has($file), "File $file should be created");
+        }
+    }
 
     private function write($name, $content = null)
     {

--- a/tests/Karma/HydratorTest.php
+++ b/tests/Karma/HydratorTest.php
@@ -151,7 +151,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         
         foreach($existingFiles as $file)
         {
-            $this->assertFalse($this->targetFs->has($file), "File $file should'nt have been overwritted");
+            $this->assertFalse($this->targetFs->has($file), "File $file should'nt be overwritten");
         }
     }
     

--- a/tests/Karma/HydratorTest.php
+++ b/tests/Karma/HydratorTest.php
@@ -12,12 +12,14 @@ use Karma\Formatters\Rules;
 class HydratorTest extends \PHPUnit_Framework_TestCase
 {
     private
-        $fs,
+        $sourceFs,
+        $targetFs,
         $hydrator;
 
     protected function setUp()
     {
-        $this->fs = new Filesystem(new InMemory());
+        $this->sourceFs = new Filesystem(new InMemory());
+        $this->targetFs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var:dev' => 42,
             'var:preprod' => 51,
@@ -32,7 +34,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
             'fixme:dev' => '__FIXME__',
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs), new NullProvider());
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs), new NullProvider());
         $this->hydrator->setSuffix('-dist');
     }
 
@@ -51,17 +53,37 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
 
         $this->hydrator->hydrate($environment);
 
-        $this->assertTrue($this->fs->has('b.php'));
-        $this->assertTrue($this->fs->has('d.php'));
-        $this->assertTrue($this->fs->has('e.php'));
-        $this->assertTrue($this->fs->has('f.php'));
+        $this->assertTrue($this->targetFs->has('b.php'));
+        $this->assertFalse($this->targetFs->has('c.php'));
+        $this->assertTrue($this->targetFs->has('d.php'));
+        $this->assertTrue($this->targetFs->has('e.php'));
+        $this->assertTrue($this->targetFs->has('f.php'));
 
-        $this->assertSame($expectedBValue, $this->fs->read('b.php'));
+        $this->assertSame($expectedBValue, $this->targetFs->read('b.php'));
 
-        $this->assertSame('<%var%>', $this->fs->read('c.php'));
-        $this->assertSame('var', $this->fs->read('d.php'));
-        $this->assertSame('<%var %>', $this->fs->read('e.php'));
-        $this->assertSame($expectedFValue, $this->fs->read('f.php'));
+        $this->assertSame('<%var%>', $this->sourceFs->read('c.php'));
+        
+        $this->assertSame('var', $this->targetFs->read('d.php'));
+        $this->assertSame('<%var %>', $this->targetFs->read('e.php'));
+        $this->assertSame($expectedFValue, $this->targetFs->read('f.php'));
+    }
+
+    public function testTarget()
+    {
+        $this->write('a.php-dist', '<%var%>');
+        $this->write('b.php', '<%var%>');
+        $reader = new InMemoryReader([
+            'var:dev' => 'test',
+        ]);
+
+        $hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs), new NullProvider());
+        $hydrator->allowNonDistFilesOverwrite();
+        $hydrator->hydrate('dev');
+
+        $this->assertTrue($this->targetFs->has('a.php'));
+        $this->assertSame('test', $this->targetFs->read('a.php'));
+        $this->assertTrue($this->targetFs->has('b.php'));
+        $this->assertSame('test', $this->targetFs->read('b.php'));
     }
 
     public function providerTestSimple()
@@ -82,7 +104,7 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
             ->setDryRun()
             ->hydrate('dev');
 
-        $this->assertFalse($this->fs->has('b.php'));
+        $this->assertFalse($this->targetFs->has('b.php'));
     }
 
     public function testGetUnusedVariables()
@@ -120,49 +142,79 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $allFiles = array_merge($existingFiles, $createdFiles);
 
         // check there is no extra generated file
-        $this->assertSame(count($allFiles), count($this->fs->keys()));
+        $this->assertSame(count($createdFiles), count($this->targetFs->keys()));
 
-        foreach($allFiles as $file)
+        foreach($createdFiles as $file)
         {
-            $this->assertTrue($this->fs->has($file), "File $file should be created");
+            $this->assertTrue($this->targetFs->has($file), "File $file should be created");
+        }
+        
+        foreach($existingFiles as $file)
+        {
+            $this->assertFalse($this->targetFs->has($file), "File $file should'nt have been overwritted");
         }
     }
+    
+    public function testTrappedFilenamesToTarget()
+    {
+        $existingFiles = array('a.php', 'b.php-dist', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php', 'h.php-dist-dist');
+    
+        foreach($existingFiles as $file)
+        {
+            $this->write($file);
+        }
+    
+        $this->hydrator
+            ->allowNonDistFilesOverwrite()
+            ->hydrate('prod');
+    
+        $expectedFiles = array('b.php', 'h.php-dist', 'a.php', 'c.php-dis', 'd.php-distt', 'e.php-dist.dist', 'f.dist', 'g-dist.php');
+        
+        // check there is no extra generated file
+        $this->assertSame(count($expectedFiles), count($this->targetFs->keys()));
+
+        foreach($expectedFiles as $file)
+        {
+            $this->assertTrue($this->targetFs->has($file), "File $file should be created");
+        }
+    }
+    
 
     private function write($name, $content = null)
     {
-        $this->fs->write($name, $content);
+        $this->sourceFs->write($name, $content);
     }
 
     public function testBackupFiles()
     {
         $this->write('a.php-dist');
         $this->write('b.php-dist', '<%var%>');
-        $this->write('b.php', 'oldValue');
+        $this->targetFs->write('b.php', 'oldValue');
         $this->write('c.php-dist');
 
         $this->hydrator
             ->enableBackup()
             ->hydrate('dev');
 
-        $this->assertTrue($this->fs->has('a.php'));
-        $this->assertFalse($this->fs->has('a.php~'));
+        $this->assertTrue($this->targetFs->has('a.php'));
+        $this->assertFalse($this->targetFs->has('a.php~'));
 
-        $this->assertTrue($this->fs->has('b.php'));
-        $this->assertTrue($this->fs->has('b.php~'));
+        $this->assertTrue($this->targetFs->has('b.php'));
+        $this->assertTrue($this->targetFs->has('b.php~'));
 
-        $this->assertTrue($this->fs->has('c.php'));
-        $this->assertFalse($this->fs->has('c.php~'));
+        $this->assertTrue($this->targetFs->has('c.php'));
+        $this->assertFalse($this->targetFs->has('c.php~'));
 
-        $this->assertSame('42', $this->fs->read('b.php'));
-        $this->assertSame('oldValue', $this->fs->read('b.php~'));
+        $this->assertSame('42', $this->targetFs->read('b.php'));
+        $this->assertSame('oldValue', $this->targetFs->read('b.php~'));
 
         $this->hydrator->hydrate('dev');
 
-        $this->assertTrue($this->fs->has('a.php~'));
-        $this->assertTrue($this->fs->has('b.php~'));
-        $this->assertTrue($this->fs->has('c.php~'));
+        $this->assertTrue($this->targetFs->has('a.php~'));
+        $this->assertTrue($this->targetFs->has('b.php~'));
+        $this->assertTrue($this->targetFs->has('c.php~'));
 
-        $this->assertSame('42', $this->fs->read('b.php~'));
+        $this->assertSame('42', $this->targetFs->read('b.php~'));
     }
 
     public function testFormatter()
@@ -188,13 +240,13 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->write('list-dist', "<%list%>\n<%karma:formatter=YeLl     %>   \n");
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame('string_true', $this->fs->read('a'));
-        $this->assertSame('TRUE', $this->fs->read('b'));
-        $this->assertSame(implode("\n", array("str", 2, "TRUE", null)). "\n", $this->fs->read('list'));
+        $this->assertSame('string_true', $this->targetFs->read('a'));
+        $this->assertSame('TRUE', $this->targetFs->read('b'));
+        $this->assertSame(implode("\n", array("str", 2, "TRUE", null)). "\n", $this->targetFs->read('list'));
 
         $this->hydrator->hydrate('prod');
-        $this->assertSame('0', $this->fs->read('a'));
-        $this->assertSame('FALSE', $this->fs->read('b'));
+        $this->assertSame('0', $this->targetFs->read('a'));
+        $this->assertSame('FALSE', $this->targetFs->read('b'));
     }
 
     public function testFormatterByFileExtension()
@@ -236,11 +288,11 @@ class HydratorTest extends \PHPUnit_Framework_TestCase
         $this->write('e.yml-dist', "<% karma:formatter = int %>\n<%bool%>");
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame('1', $this->fs->read('a.ini'));
-        $this->assertSame('TRUE', $this->fs->read('b.yml'));
-        $this->assertSame('string_true', $this->fs->read('c.txt'));
-        $this->assertSame('TRUE', $this->fs->read('d.cfg')); // default
-        $this->assertSame('1', $this->fs->read('e.yml'));
+        $this->assertSame('1', $this->targetFs->read('a.ini'));
+        $this->assertSame('TRUE', $this->targetFs->read('b.yml'));
+        $this->assertSame('string_true', $this->targetFs->read('c.txt'));
+        $this->assertSame('TRUE', $this->targetFs->read('d.cfg')); // default
+        $this->assertSame('1', $this->targetFs->read('e.yml'));
     }
 
     /**
@@ -289,14 +341,13 @@ FILE
      */
     public function testList($env, $expected)
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var:dev' => array(42, 51, 69, 'some string'),
             'var:staging' => array(33),
             'var:prod' => 1337,
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
         $this->write('a.yml-dist', <<< YAML
 array:
@@ -305,7 +356,7 @@ YAML
         );
 
         $this->hydrator->hydrate($env);
-        $this->assertSame($expected, $this->fs->read('a.yml'));
+        $this->assertSame($expected, $this->targetFs->read('a.yml'));
     }
 
     public function providerTestList()
@@ -334,12 +385,11 @@ YAML
 
     public function testListMultiFormat()
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var:dev' => array(42, 51, 69),
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
         $this->write('a.php-dist', <<< PHP
 \$var = array(
@@ -369,20 +419,19 @@ list[]=69
 INI;
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame($expectedPhp, $this->fs->read('a.php'));
-        $this->assertSame($expectedIni, $this->fs->read('b.ini'));
+        $this->assertSame($expectedPhp, $this->targetFs->read('a.php'));
+        $this->assertSame($expectedIni, $this->targetFs->read('b.ini'));
     }
 
     public function testListEdgeCases()
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var:dev' => array(42, 51),
             'foo:dev' => 33,
             'bar:dev' => array(1337, 1001),
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
         $this->write('a.txt-dist', <<< TXT
 foo = <%var%> <%foo%>
@@ -409,7 +458,7 @@ baz = 1001 1001 1001
 TXT;
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame($expected, $this->fs->read('a.txt'));
+        $this->assertSame($expected, $this->targetFs->read('a.txt'));
     }
 
     /**
@@ -417,17 +466,16 @@ TXT;
      */
     public function testListEndOfLine($content, $expected)
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var:dev' => array(42, 51),
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
         $this->write('a.txt-dist', $content);
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame($expected, $this->fs->read('a.txt'));
+        $this->assertSame($expected, $this->targetFs->read('a.txt'));
     }
 
     public function providerTestListEndOfLine()
@@ -444,7 +492,6 @@ TXT;
      */
     public function testListDirective($content, $env, $expected)
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'items:dev' => array(42, 51, 69, 'someString'),
             'items:staging' => array(33),
@@ -454,12 +501,12 @@ TXT;
             'servers:prod' => array('a', 'b', 'c'),
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
         $this->write('a-dist', $content);
 
         $this->hydrator->hydrate($env);
-        $this->assertSame($expected, $this->fs->read('a'));
+        $this->assertSame($expected, $this->targetFs->read('a'));
     }
 
     public function providerTestListDirective()
@@ -634,13 +681,12 @@ TXT;
 
     public function testMultipleListDirective()
     {
-        $this->fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'items:dev' => array(42, 51, 69, 'someString'),
             'servers:dev' => array('a', 'b', 'c'),
         ));
 
-        $this->hydrator = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
         $this->hydrator->setFormatterProvider(new CallbackProvider(function() {
             return new Rules(array('<string>' => '"<string>"'));
         }));
@@ -656,23 +702,22 @@ FILE
 42@51@69@"someString"
 "a"_"b"_"c"
 FILE
-        , $this->fs->read('a'));
+        , $this->targetFs->read('a'));
     }
 
     public function testDashesInVariableNameAreAllowed()
     {
-        $fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'var-with-dashes:dev' => 'poney',
             'dash-dash-dash:dev' => 'licorne',
         ));
 
-        $this->hydrator = new Hydrator($fs, $reader, new Finder($fs));
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
 
-        $fs->write('a-dist', '<%var-with-dashes%> = <%dash-dash-dash%>');
+        $this->sourceFs->write('a-dist', '<%var-with-dashes%> = <%dash-dash-dash%>');
 
         $this->hydrator->hydrate('dev');
-        $this->assertSame('poney = licorne', $fs->read('a'));
+        $this->assertSame('poney = licorne', $this->targetFs->read('a'));
     }
 
     /**
@@ -680,7 +725,6 @@ FILE
      */
     public function testHydrateWithADifferentSystemEnvironment($env, $systemEnv, $expectedA, $expectedList, $expectedDirective)
     {
-        $fs = new Filesystem(new InMemory());
         $reader = new InMemoryReader(array(
             'poney:dev' => 'poney_d',
             'poney:staging' => 'poney_s',
@@ -692,18 +736,18 @@ FILE
             '@dsn:staging' => array('s', 't', 'a'),
         ));
 
-        $this->hydrator = new Hydrator($fs, $reader, new Finder($fs));
-        $fs->write('a-dist', '<%poney%> = <%licorne%>');
-        $fs->write('list-dist', "<%dsn%>\n<%env%>");
-        $fs->write('directive-dist', '<% karma:list var=dsn delimiter="" %> = <% karma:list var=env delimiter="" %>');
+        $this->hydrator = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
+        $this->sourceFs->write('a-dist', '<%poney%> = <%licorne%>');
+        $this->sourceFs->write('list-dist', "<%dsn%>\n<%env%>");
+        $this->sourceFs->write('directive-dist', '<% karma:list var=dsn delimiter="" %> = <% karma:list var=env delimiter="" %>');
 
         $this->hydrator
             ->setSystemEnvironment($systemEnv)
             ->hydrate($env);
 
-        $this->assertSame($expectedA, $fs->read('a'));
-        $this->assertSame($expectedList, $fs->read('list'));
-        $this->assertSame($expectedDirective, $fs->read('directive'));
+        $this->assertSame($expectedA, $this->targetFs->read('a'));
+        $this->assertSame($expectedList, $this->targetFs->read('list'));
+        $this->assertSame($expectedDirective, $this->targetFs->read('directive'));
     }
 
     public function providerTestHydrateWithADifferentSystemEnvironment()

--- a/tests/Karma/ProfileReaderTest.php
+++ b/tests/Karma/ProfileReaderTest.php
@@ -100,6 +100,7 @@ suffix: -tpl
 master: othermaster.conf
 confDir: env2/
 sourcePath: lib/
+targetPath: target/
 generator:
   translator: prefix
 YAML;
@@ -117,6 +118,9 @@ YAML;
 
         $this->assertTrue($reader->hasSourcePath());
         $this->assertSame('lib/', $reader->getSourcePath());
+
+        $this->assertTrue($reader->hasTargetPath());
+        $this->assertSame('target/', $reader->getTargetPath());
 
         $this->assertSame(array('translator' => 'prefix'), $reader->getGeneratorOptions());
     }
@@ -155,6 +159,20 @@ YAML;
     public function testSyntaxError()
     {
         $this->buildReader("\tsuffix:-tpl");
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testTargetPathAsArray()
+    {
+        $yaml = <<<YAML
+targetPath:
+    - path1/
+    - path2/
+YAML;
+
+        $reader = $this->buildReader($yaml);
     }
 
     public function testInvalidFormat()

--- a/tests/Karma/RollbackTest.php
+++ b/tests/Karma/RollbackTest.php
@@ -9,11 +9,14 @@ use Karma\Configuration\Reader;
 class RollbackTest extends \PHPUnit_Framework_TestCase
 {
     private
+        $sourceFs,
+        $targetFs,
         $rollback;
 
     protected function setUp()
     {
-        $this->fs = new Filesystem(new InMemory());
+        $this->sourceFs = new Filesystem(new InMemory());
+        $this->targetFs = new Filesystem(new InMemory());
 
         $this->write('a.php-dist', 'a');
         $this->write('a.php', 'a');
@@ -42,7 +45,7 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
         $this->write('subdir/s.php~', 'old_s');
 
         $reader = new Reader(array(), array());
-        $this->rollback = new Hydrator($this->fs, $reader, new Finder($this->fs));
+        $this->rollback = new Hydrator($this->sourceFs, $this->targetFs, $reader, new Finder($this->sourceFs));
     }
 
     public function testRollback()
@@ -81,13 +84,13 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         foreach($shouldExists as $f => $content)
         {
-            $this->assertTrue($this->fs->has($f), "File $f should exists");
-            $this->assertSame($content, $this->fs->read($f));
+            $this->assertTrue($this->sourceFs->has($f), "File $f should exists");
+            $this->assertSame($content, $this->sourceFs->read($f));
         }
 
         foreach($shouldNotExists as $f)
         {
-            $this->assertFalse($this->fs->has($f), "File should not exists");
+            $this->assertFalse($this->sourceFs->has($f), "File should not exists");
         }
     }
 
@@ -127,18 +130,18 @@ class RollbackTest extends \PHPUnit_Framework_TestCase
 
         foreach($shouldExists as $f => $content)
         {
-            $this->assertTrue($this->fs->has($f), "File $f should exists");
-            $this->assertSame($content, $this->fs->read($f));
+            $this->assertTrue($this->sourceFs->has($f), "File $f should exists");
+            $this->assertSame($content, $this->sourceFs->read($f));
         }
 
         foreach($shouldNotExists as $f)
         {
-            $this->assertFalse($this->fs->has($f), "File should not exists");
+            $this->assertFalse($this->sourceFs->has($f), "File should not exists");
         }
     }
 
     private function write($name, $content = null)
     {
-        $this->fs->write($name, $content);
+        $this->sourceFs->write($name, $content);
     }
 }


### PR DESCRIPTION
Add ability to define a target path for config output. 

Param **targetPath** can be set in profile or as command param

Behavior change : if set, all config files (not only *-dist) are generated in target dir.
No BC break.